### PR TITLE
Incompatible declaration of values()-method

### DIFF
--- a/src/Migrator/Pipes/CreateNewMetadata.php
+++ b/src/Migrator/Pipes/CreateNewMetadata.php
@@ -149,13 +149,13 @@ class CreateNewMetadata
                 ['metadata_id', 'settable_id', 'settable_type', 'value', 'created_at', 'updated_at'],
                 $model->newQuery()
                     ->select([
-                    DB::raw("'{$metadata->getKey()}' as metadata_id"),
-                    DB::raw("{$model->getKeyName()} as settable_id"),
-                    DB::raw("'". addcslashes($model->getMorphClass(), '\\') ."' as settable_type"),
-                    DB::raw("'{$metadata->getRawOriginal('default', 'NULL')}' as value"),
-                    DB::raw("'{$this->now->toDateTimeString()}' as created_at"),
-                    DB::raw("'{$this->now->toDateTimeString()}' as updated_at"),
-                ])->getQuery()
+                        DB::raw("'{$metadata->getKey()}' as metadata_id"),
+                        DB::raw("{$model->getKeyName()} as settable_id"),
+                        DB::raw("'". addcslashes($model->getMorphClass(), '\\') ."' as settable_type"),
+                        DB::raw((!is_null($metadata->getRawOriginal('default')) ? "'{$metadata->getRawOriginal('default')}'" : "NULL") . " as value"),
+                        DB::raw("'{$this->now->toDateTimeString()}' as created_at"),
+                        DB::raw("'{$this->now->toDateTimeString()}' as updated_at"),
+                    ])->getQuery()
             );
         }
 

--- a/src/SettingsCollection.php
+++ b/src/SettingsCollection.php
@@ -59,7 +59,7 @@ class SettingsCollection extends Collection
      *
      * @return Carbon|\Illuminate\Support\Collection|array|string|int|float|bool|null
      */
-    public function value(string $name, mixed $default = null): Carbon|Collection|array|string|int|float|bool|null
+    public function value($name, $default = null): Carbon|Collection|array|string|int|float|bool|null
     {
         $setting = $this->get($name, $default);
 


### PR DESCRIPTION
The values-method in the SettingsCollection is incompatible with latest Illuminate Collection versions. Since v9.13.0.

See also https://github.com/laravel/framework/pull/42257.