### PR TITLE
Incompatible declaration of values()-method

### DIFF
--- a/src/SettingsCollection.php
+++ b/src/SettingsCollection.php
@@ -59,7 +59,7 @@ class SettingsCollection extends Collection
      *
      * @return Carbon|\Illuminate\Support\Collection|array|string|int|float|bool|null
      */
-    public function value(string $name, mixed $default = null): Carbon|Collection|array|string|int|float|bool|null
+    public function value($name, $default = null): Carbon|Collection|array|string|int|float|bool|null
     {
         $setting = $this->get($name, $default);
 


### PR DESCRIPTION
The values-method in the SettingsCollection is incompatible with latest illuminate versions. Since v9.13.0.

See also https://github.com/laravel/framework/pull/42257